### PR TITLE
Fix watchdog overload message newline

### DIFF
--- a/ES-Lab-Kit/Software/Projects/task2_crusie_control/main.c
+++ b/ES-Lab-Kit/Software/Projects/task2_crusie_control/main.c
@@ -186,7 +186,7 @@ void vWatchDogTask(void *args){
     for(;;){
         isFeed = (xSemaphoreTake(xSemaphoreWatchDogFood, xPeriod) == pdTRUE);
         if(!isFeed){
-            printf("System Overload!/n");
+            printf("System Overload!\n");
         }
         vTaskDelayUntil(&xLastWakeTime, xPeriod);
     }


### PR DESCRIPTION
## Summary
- correct the newline escape sequence in the watchdog overload message

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddc74d53888331a1616d5c38d3da71